### PR TITLE
Question: License on cyrb53?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+


### PR DESCRIPTION
Hello,

This PR isn't anything real; it's just the only way I found to get in contact with you. Sorry for contacting you in such a strange way.

I want to use the cyrb53 hashing function you posted on StackOverflow a while ago in a game project: https://stackoverflow.com/a/52171480/868460

But StackOverflow says it's licensed CC BY-SA 4.0. My project can't be licensed sharealike, so that means I can't use it. Since you seem to have written it with the intent that others would use it, that "sharealike" part of the license seems strange. Was your intention to use that license? I think that's Stack Overflow's default license.

Would you be willing to relicense that code under a more permissive license, so I can use it in my game? Public Domain, MIT, CC-BY-3.0 US, etc?

For public domain, all you need to do is say in a reply "I release this work to the public domain"

For MIT, you would copy/paste the MIT license, change the copyright year and put in your name, and distribute cyrb53 alongside that license, ie. in a comment above the code in the original stackoverflow answer, or in a github repo or http page or etc.

For CC-BY-3.0 US, you'd do the same process as MIT but with something like this:
```js
// This code is made available under the Creative Commons attribution 3.0 license (CC-BY-3.0 US):
// Attribution in source code comments (even closed-source/commercial code) is sufficient.
// License summary and text available at: https://creativecommons.org/licenses/by/3.0/us/
```